### PR TITLE
Disable multiple connections

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,6 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 					})
 				)
 				ws.close()
-				return
 			}
 			this.clients.add(ws)
 			this.setVariableValues({ [Variables.IS_CONNECTED]: true })


### PR DESCRIPTION
[Related issue](https://github.com/Eyevinn/intercom-frontend/issues/402)
This PR needs to be merged **_after_** the PR made for [frontend](https://github.com/Eyevinn/intercom-frontend/pull/524) for easy and error-free implementation.

**Background:**
As of now, if one is to connect the same companion on multiple browsers, intercom allows for it and causes confusion for the companion. This is not good, since the companion now works for both browsers, and causes the companion to not know exactly which production and line it is in.

**Solution:**
This PR ensures that if one is to connect a companion on multiple browsers, an error with statuscode 409 is sent so that the frontend can handle it and show an error for the user. 